### PR TITLE
Fix slice allocator to be non-moving and add unit test

### DIFF
--- a/allocator/nonmoving.go
+++ b/allocator/nonmoving.go
@@ -6,7 +6,7 @@ import (
 	"github.com/tetratelabs/wazero/experimental"
 )
 
-var errOutOfMemory = errors.New("allocator: requested size exceeds reserved address space")
+var errInvalidReallocation = errors.New("allocator: invalid reallocation request: size exceeds reserved address space")
 
 // NewNonMoving returns a [experimental.MemoryAllocator] that will reserve
 // address space up to the maximum requested by a WebAssembly module during

--- a/allocator/nonmoving.go
+++ b/allocator/nonmoving.go
@@ -1,6 +1,12 @@
 package allocator
 
-import "github.com/tetratelabs/wazero/experimental"
+import (
+	"errors"
+
+	"github.com/tetratelabs/wazero/experimental"
+)
+
+var errOutOfMemory = errors.New("allocator: requested size exceeds reserved address space")
 
 // NewNonMoving returns a [experimental.MemoryAllocator] that will reserve
 // address space up to the maximum requested by a WebAssembly module during

--- a/allocator/nonmoving_other.go
+++ b/allocator/nonmoving_other.go
@@ -4,22 +4,8 @@ package allocator
 
 import "github.com/tetratelabs/wazero/experimental"
 
+var pageSize = 0 // used only for test
+
 func alloc(cap, max uint64) experimental.LinearMemory {
-	return &sliceBuffer{make([]byte, cap), max}
-}
-
-type sliceBuffer struct {
-	buf []byte
-	max uint64
-}
-
-func (b *sliceBuffer) Free() {}
-
-func (b *sliceBuffer) Reallocate(size uint64) []byte {
-	if cap := uint64(cap(b.buf)); size > cap {
-		b.buf = append(b.buf[:cap], make([]byte, size-cap)...)
-	} else {
-		b.buf = b.buf[:size]
-	}
-	return b.buf
+	return sliceAlloc(cap, max)
 }

--- a/allocator/nonmoving_slice.go
+++ b/allocator/nonmoving_slice.go
@@ -18,7 +18,7 @@ func (b *sliceBuffer) Free() {}
 
 func (b *sliceBuffer) Reallocate(size uint64) []byte {
 	if int(size) > cap(b.buf) {
-		panic(errOutOfMemory)
+		panic(errInvalidReallocation)
 	}
 	return b.buf[:size]
 }

--- a/allocator/nonmoving_slice.go
+++ b/allocator/nonmoving_slice.go
@@ -1,0 +1,24 @@
+package allocator
+
+import "github.com/tetratelabs/wazero/experimental"
+
+// Separate implementation of non-Unix/Windows code to file without
+// build tag to allow testing on any platform.
+
+func sliceAlloc(_, max uint64) experimental.LinearMemory {
+	buf := make([]byte, max)
+	return &sliceBuffer{buf: buf[:0]}
+}
+
+type sliceBuffer struct {
+	buf []byte
+}
+
+func (b *sliceBuffer) Free() {}
+
+func (b *sliceBuffer) Reallocate(size uint64) []byte {
+	if int(size) > cap(b.buf) {
+		panic(errOutOfMemory)
+	}
+	return b.buf[:size]
+}

--- a/allocator/nonmoving_test.go
+++ b/allocator/nonmoving_test.go
@@ -1,0 +1,57 @@
+package allocator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/experimental"
+)
+
+func TestNonMoving(t *testing.T) {
+	tests := []struct {
+		name string
+		mem  experimental.LinearMemory
+		cap  int
+	}{
+		{
+			name: "native",
+			mem:  NewNonMoving().Allocate(10, 20),
+			cap:  int(pageSize),
+		},
+		// The non-slice allocators are available on all normal platforms. Rather than requiring qemu to test slice
+		// allocator, we just go ahead and test it in addition to the native one. On platforms other than unix/windows,
+		// it will test the same allocator twice, which is fine.
+		{
+			name: "slice",
+			mem:  sliceAlloc(10, 20),
+			cap:  20,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			mem := tc.mem
+			defer mem.Free()
+
+			buf := mem.Reallocate(5)
+			require.Equal(t, 5, len(buf))
+			require.Equal(t, tc.cap, cap(buf))
+			base := &buf[0]
+
+			buf = mem.Reallocate(5)
+			require.Equal(t, 5, len(buf))
+			require.Equal(t, base, &buf[0])
+
+			buf = mem.Reallocate(10)
+			require.Equal(t, 10, len(buf))
+			require.Equal(t, base, &buf[0])
+
+			buf = mem.Reallocate(20)
+			require.Equal(t, 20, len(buf))
+			require.Equal(t, base, &buf[0])
+
+			require.PanicsWithError(t, errOutOfMemory.Error(), func() { mem.Reallocate(21) })
+		})
+	}
+}

--- a/allocator/nonmoving_test.go
+++ b/allocator/nonmoving_test.go
@@ -51,7 +51,7 @@ func TestNonMoving(t *testing.T) {
 			require.Equal(t, 20, len(buf))
 			require.Equal(t, base, &buf[0])
 
-			require.PanicsWithError(t, errOutOfMemory.Error(), func() { mem.Reallocate(21) })
+			require.PanicsWithError(t, errInvalidReallocation.Error(), func() { mem.Reallocate(21) })
 		})
 	}
 }

--- a/allocator/nonmoving_unix.go
+++ b/allocator/nonmoving_unix.go
@@ -44,7 +44,7 @@ type mmappedMemory struct {
 
 func (m *mmappedMemory) Reallocate(size uint64) []byte {
 	if size > m.max {
-		panic(errOutOfMemory)
+		panic(errInvalidReallocation)
 	}
 
 	com := uint64(len(m.buf))

--- a/allocator/nonmoving_unix.go
+++ b/allocator/nonmoving_unix.go
@@ -10,37 +10,45 @@ import (
 	"github.com/tetratelabs/wazero/experimental"
 )
 
-func alloc(_, max uint64) experimental.LinearMemory {
-	// Round up to the page size.
-	rnd := uint64(syscall.Getpagesize() - 1)
-	max = (max + rnd) &^ rnd
+var pageSize = syscall.Getpagesize()
 
-	if max > math.MaxInt {
+func alloc(_, max uint64) experimental.LinearMemory {
+	// Round up to the page size because recommitting must be page-aligned.
+	// In practice, the WebAssembly page size should be a multiple of the system
+	// page size on most if not all platforms and rounding will never happen.
+	rnd := uint64(pageSize - 1)
+	reserved := (max + rnd) &^ rnd
+
+	if reserved > math.MaxInt {
 		// This ensures int(max) overflows to a negative value,
 		// and syscall.Mmap returns EINVAL.
-		max = math.MaxUint64
+		reserved = math.MaxUint64
 	}
 
 	// Reserve max bytes of address space, to ensure we won't need to move it.
 	// A protected, private, anonymous mapping should not commit memory.
-	b, err := syscall.Mmap(-1, 0, int(max), syscall.PROT_NONE, syscall.MAP_PRIVATE|syscall.MAP_ANON)
+	b, err := syscall.Mmap(-1, 0, int(reserved), syscall.PROT_NONE, syscall.MAP_PRIVATE|syscall.MAP_ANON)
 	if err != nil {
 		panic(fmt.Errorf("allocator_unix: failed to reserve memory: %w", err))
 	}
-	return &mmappedMemory{buf: b[:0]}
+	return &mmappedMemory{buf: b[:0], max: max}
 }
 
 // The slice covers the entire mmapped memory:
 //   - len(buf) is the already committed memory,
-//   - cap(buf) is the reserved address space.
+//   - cap(buf) is the reserved address space, which is max rounded up to a page.
 type mmappedMemory struct {
 	buf []byte
+	max uint64
 }
 
 func (m *mmappedMemory) Reallocate(size uint64) []byte {
+	if size > m.max {
+		panic(errOutOfMemory)
+	}
+
 	com := uint64(len(m.buf))
-	res := uint64(cap(m.buf))
-	if com < size && size < res {
+	if com < size {
 		// Round up to the page size.
 		rnd := uint64(syscall.Getpagesize() - 1)
 		new := (size + rnd) &^ rnd

--- a/allocator/nonmoving_windows.go
+++ b/allocator/nonmoving_windows.go
@@ -45,7 +45,7 @@ func alloc(_, max uint64) experimental.LinearMemory {
 		panic(fmt.Errorf("allocator_windows: failed to reserve memory: %w", err))
 	}
 
-	buf := unsafe.Slice((*byte)(unsafe.Pointer(r)), int(max))
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(r)), int(reserved))
 	return &virtualMemory{buf: buf[:0], addr: r, max: max}
 }
 

--- a/allocator/nonmoving_windows.go
+++ b/allocator/nonmoving_windows.go
@@ -60,7 +60,7 @@ type virtualMemory struct {
 
 func (m *virtualMemory) Reallocate(size uint64) []byte {
 	if size > m.max {
-		panic(errOutOfMemory)
+		panic(errInvalidReallocation)
 	}
 
 	com := uint64(len(m.buf))

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/wasilibs/wazero-helpers
 go 1.20
 
 require github.com/tetratelabs/wazero v1.7.2
+
+require github.com/stretchr/testify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tetratelabs/wazero v1.7.2 h1:1+z5nXJNwMLPAWaTePFi49SSTL0IMx/i3Fg8Yc25GDc=
 github.com/tetratelabs/wazero v1.7.2/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=


### PR DESCRIPTION
I realized I copied sqlite's slice allocator without taking a look at it, in that repo there probably isn't a use case for a non-moving slice allocator, but here we should make sure it behaves the same as the others in case it is used with shared memory.

I also noticed that `Reallocate(size)` greater than max but less than rounded up to page works. In practice, wazero shouldn't make such a reservation, I think, but it seemed to make sense to preseve those semantics in the allocators as well.

Also fixes windows error handling